### PR TITLE
Add "t" option to rsync

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -32,7 +32,7 @@ applyCustomConfigs() {
 
   if [ -d "$CSGO_CUSTOM_CONFIGS_DIR" ]; then
       echo '> Found custom configs, applying ...'
-      rsync -ri $CSGO_CUSTOM_CONFIGS_DIR/ $CSGO_DIR
+      rsync -rti $CSGO_CUSTOM_CONFIGS_DIR/ $CSGO_DIR
       echo '> Done'
   else
       echo '> No custom configs found to apply'

--- a/pug-practice/entrypoint.sh
+++ b/pug-practice/entrypoint.sh
@@ -69,7 +69,7 @@ applyCustomConfigs() {
 
   if [ -d "$CSGO_CUSTOM_CONFIGS_DIR" ]; then
       echo '> Found custom configs, applying ...'
-      rsync -ri $CSGO_CUSTOM_CONFIGS_DIR/ $CSGO_DIR
+      rsync -rti $CSGO_CUSTOM_CONFIGS_DIR/ $CSGO_DIR
       echo '> Done'
   else
       echo '> No custom configs found to apply'


### PR DESCRIPTION
This prevents unmodified configs/maps from being re-synced upon restart/reboot:

https://linux.die.net/man/1/rsync

>  -t, --times                 preserve modification times