### PR TITLE
Add wait-for-it

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     ca-certificates=20190110 \
     rsync=3.1.3-6 \
     unzip=6.0-23+deb10u1 \
+    wait-for-it \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m csgo

--- a/pug-practice/Dockerfile
+++ b/pug-practice/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     ca-certificates=20190110 \
     rsync=3.1.3-6 \
     unzip=6.0-23+deb10u1 \
+    wait-for-it \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m csgo


### PR DESCRIPTION
Add wait-for-it to image for admins who would like to run separate docker containers for each instance of srcds. This allows you to share a single installation volume across multiple containers, while ensuring that updates are only run on a single container. For example:

https://github.com/Gelmo/warfork-docker/blob/master/docker-compose.multi-container.yml

In that example, warfork2 and warfork3 wait until port 44450 is open on warfork1 before running the entrypoint script. The same functionality is available with HEALTHCHECK, but this tool allows for similar functionality when checking instances on another node/host/stack