### PR TITLE
Add quotes around hostname variable

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -60,7 +60,7 @@ startServer() {
   fi
 
   if [ -n "$CSGO_HOSTNAME" ]; then
-    optionalParameters+=" +hostname $CSGO_HOSTNAME"
+    optionalParameters+=" +hostname '$CSGO_HOSTNAME'"
   fi
 
   if [ -n "$CSGO_WS_API_KEY" ]; then

--- a/pug-practice/entrypoint.sh
+++ b/pug-practice/entrypoint.sh
@@ -97,7 +97,7 @@ startServer() {
   fi
 
   if [ -n "$CSGO_HOSTNAME" ]; then
-    optionalParameters+=" +hostname $CSGO_HOSTNAME"
+    optionalParameters+=" +hostname '$CSGO_HOSTNAME'"
   fi
 
   if [ -n "$CSGO_WS_API_KEY" ]; then


### PR DESCRIPTION
If your hostname had spaces in it, everything after the first space
would be truncated. So "My Server" would just show as "My" in the server
browser. This resolves the issue.