### PR TITLE
Fix quoting of hostname

### DIFF
--- a/base/entrypoint.sh
+++ b/base/entrypoint.sh
@@ -60,7 +60,7 @@ startServer() {
   fi
 
   if [ -n "$CSGO_HOSTNAME" ]; then
-    optionalParameters+=" +hostname '$CSGO_HOSTNAME'"
+    optionalParameters+=" +hostname "'"'"$CSGO_HOSTNAME"'"'
   fi
 
   if [ -n "$CSGO_WS_API_KEY" ]; then

--- a/pug-practice/entrypoint.sh
+++ b/pug-practice/entrypoint.sh
@@ -97,7 +97,7 @@ startServer() {
   fi
 
   if [ -n "$CSGO_HOSTNAME" ]; then
-    optionalParameters+=" +hostname '$CSGO_HOSTNAME'"
+    optionalParameters+=" +hostname "'"'"$CSGO_HOSTNAME"'"'
   fi
 
   if [ -n "$CSGO_WS_API_KEY" ]; then


### PR DESCRIPTION
Turns out my previous quoting wasn't sufficient. For some reason it only
works with double-quotes.