### PR TITLE
base: set force_install_dir before login

### DIFF
--- a/base/server.sh
+++ b/base/server.sh
@@ -20,8 +20,8 @@ install() {
   set -x
 
   $steam_dir/steamcmd.sh \
-    +login anonymous \
     +force_install_dir $server_dir \
+    +login anonymous \
     +app_update 740 validate \
     +quit
 


### PR DESCRIPTION
SteamCMD will send a warning about using `force_install_dir` before logon because of this issue here: https://github.com/ValveSoftware/steam-for-linux/issues/8298

```
> Installing server ...
+ /home/csgo/Steam/steamcmd.sh +login anonymous +force_install_dir /home/csgo/server +app_update 740 validate +quit
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/home/csgo/Steam/logs/stderr.txt'
[ 0%] Checking for available updates...
[----] Verifying installation...
[ 0%] Downloading update...
[ 0%] Checking for available updates...
[----] Download complete.
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Extracting package...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Installing update...
[----] Cleaning up...
[----] Update complete, launching Steamcmd...
WARNING: setlocale('en_US.UTF-8') failed, using locale: 'C'. International characters may not work.
Redirecting stderr to '/home/csgo/Steam/logs/stderr.txt'
[ 0%] Checking for available updates...
[----] Verifying installation...
Steam Console Client (c) Valve Corporation - version 1647446802
-- type 'quit' to exit --
Loading Steam API...OK
Connecting anonymously to Steam Public...Connectivity test: result=Connected, in progress=0
OK
Waiting for client config...OK
Waiting for user info...OK
Please use force_install_dir before logon!
```