### PR TITLE
docker: add lib32z1 to base

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     rsync=3.1.3-6 \
     unzip=6.0-23+deb10u2 \
     wget=1.20.1-1.1 \
+    lib32z1=1:1.2.11.dfsg-1 \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m csgo
 

--- a/pug-practice/Dockerfile
+++ b/pug-practice/Dockerfile
@@ -1,4 +1,4 @@
-FROM timche/csgo
+FROM timche/csgo:sourcemod
 
 USER csgo
 

--- a/pug-practice/Dockerfile
+++ b/pug-practice/Dockerfile
@@ -1,4 +1,6 @@
-FROM timche/csgo:sourcemod
+FROM timche/csgo
+
+USER csgo
 
 WORKDIR /home/csgo
 

--- a/sourcemod/Dockerfile
+++ b/sourcemod/Dockerfile
@@ -1,12 +1,5 @@
 FROM timche/csgo
 
-USER root
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    lib32z1=1:1.2.11.dfsg-1 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER csgo
 
 WORKDIR /home/csgo


### PR DESCRIPTION
Hello! I'm your docker image as base for custom server setup, it uses own sourcemod versions for each server type (practice, retake and etc.) and unfortunately got this error:
`[SM] Unable to load extension "dbi.mysql.ext": libz.so.1: cannot open shared object file: No such file or directory`

We can add libz to base image to avoid such problems in future, I don't think that additional ~160KB will change anything.