### PR TITLE
docker: use bash instead of sh

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -20,7 +20,9 @@ RUN mkdir /home/csgo/Steam && \
 WORKDIR /home/csgo/Steam
 
 RUN wget -qO- https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz | tar zxf - \
-    && /home/csgo/Steam/steamcmd.sh +quit
+    && /home/csgo/Steam/steamcmd.sh +quit \
+    && mkdir -p /home/csgo/.steam/sdk32 \
+    && ln -s /home/csgo/Steam/linux32/steamclient.so /home/csgo/.steam/sdk32/steamclient.so
 
 WORKDIR /home/csgo
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update \
     unzip=6.0-23+deb10u2 \
     wget=1.20.1-1.1 \
     lib32z1=1:1.2.11.dfsg-1 \
+    locales=2.28-10 \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m csgo
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -31,4 +31,4 @@ WORKDIR /home/csgo
 
 COPY server.sh .
 
-CMD [ "/home/csgo/server.sh" ]
+CMD [ "bash", "/home/csgo/server.sh" ]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     rsync=3.1.3-6 \
     unzip=6.0-23+deb10u2 \
     wget=1.20.1-1.1 \
+    lib32z1=1:1.2.11.dfsg-1 \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -m csgo
 

--- a/base/server.sh
+++ b/base/server.sh
@@ -147,7 +147,7 @@ start() {
 
   set -x
 
-  exec $server_dir/srcds_run \
+  bash $server_dir/srcds_run \
     -game csgo \
     -console \
     -norestart \

--- a/pug-practice/Dockerfile
+++ b/pug-practice/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /home/csgo
 
 COPY server_pug_practice.sh .
 
-CMD [ "/home/csgo/server_pug_practice.sh" ]
+CMD [ "bash", "/home/csgo/server_pug_practice.sh" ]

--- a/pug-practice/Dockerfile
+++ b/pug-practice/Dockerfile
@@ -1,4 +1,6 @@
-FROM timche/csgo:sourcemod
+FROM timche/csgo
+
+USER csgo
 
 WORKDIR /home/csgo
 

--- a/sourcemod/Dockerfile
+++ b/sourcemod/Dockerfile
@@ -1,12 +1,5 @@
 FROM timche/csgo
 
-USER root
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    lib32z1=1:1.2.11.dfsg-1 \
-    && rm -rf /var/lib/apt/lists/*
-
 USER csgo
 
 WORKDIR /home/csgo

--- a/sourcemod/Dockerfile
+++ b/sourcemod/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /home/csgo
 
 COPY server_sourcemod.sh .
 
-CMD [ "/home/csgo/server_sourcemod.sh" ]
+CMD [ "bash", "/home/csgo/server_sourcemod.sh" ]


### PR DESCRIPTION
This PR fixes following errors:
```
/home/csgo/server/srcds_run: 32: /home/csgo/server/srcds_run: pushd: not found
/home/csgo/server/srcds_run: 35: /home/csgo/server/srcds_run: popd: not found
```