### PR TITLE
correctly split up the PUGSETUP_DAMAGEPRINT_CVARS

### DIFF
--- a/pug-practice/server_pug_practice.sh
+++ b/pug-practice/server_pug_practice.sh
@@ -97,9 +97,10 @@ set_damageprint_cvars() {
     pugsetup_damageprint_cfg="${csgo_dir}/cfg/sourcemod/pugsetup/pugsetup_damageprint.cfg"
 
     if [ -f "${pugsetup_damageprint_cfg}" ]; then
-      for cvar_value in $(echo $PUGSETUP_DAMAGEPRINT_CVARS | sed "s/,/ /g"); do
+      IFS=, read -ra cvar_values <<< "$PUGSETUP_DAMAGEPRINT_CVARS"
+      for cvar_value in "${cvar_values[@]}"; do
         cvar=$(echo $cvar_value | cut -f1 -d=)
-        value=$(echo $cvar_value | cut -f2 -d=)
+        value=$(echo $cvar_value | cut -f2 -d= | sed "s,/,\\\/,g")
 
         sed -i "s/${cvar} \"[^\]*\"/${cvar} \"${value}\"/g" $pugsetup_damageprint_cfg
       done


### PR DESCRIPTION
The previous code would split on spaces causing variables that contained spaces to not be set correctly.

Fixed that code to correctly split the CVARS into the appropriate variables. Also make sure to escape slashes in values to allow sed to properly replace slashes.

Example of CVAR that now works:

```
PUGSETUP_DAMAGEPRINT_CVARS="sm_pugsetup_damageprint_auto_color=0,sm_pugsetup_damageprint_format= {GREEN}To: [{DMG_TO} / {HITS_TO} hits] From: [{DMG_FROM} / {HITS_FROM} hits] - {NAME} ({HEALTH} hp)"
```

The above should set `/server/csgo/cfg/sourcemod/pugsetup/pugsetup_damageprint.cfg` to

```
sm_pugsetup_damageprint_auto_color "0"
sm_pugsetup_damageprint_format " {GREEN}To: [{DMG_TO} / {HITS_TO} hits] From: [{DMG_FROM} / {HITS_FROM} hits] - {NAME} ({HEALTH} hp)"
```

@timche could you test this change before merging it? I've only tested on a separate script when I modified it directly. I didn't test on the actual docker image